### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "built/index.js",
   "types": "src/index.ts",
   "scripts": {
-    "prepare": "shx rm -rf built && tsc",
+    "prepare": "rm -rf built && tsc",
     "start": "tsc -w --outDir demo/built"
 
   },


### PR DESCRIPTION
Remove shx from prepare script because it is breaking circleci.  It was there to fix cross platform compatibility, but all real mobile work is done on Mac/Unix.